### PR TITLE
feat: docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:16-slim as builder
+
+WORKDIR /app
+COPY tsconfig.json ./
+COPY package*.json ./
+RUN npm install --include=dev
+COPY src src
+RUN npm run build
+
+FROM node:16-slim as productionDependencies
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+
+FROM alpine as tini
+
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+FROM node:16-slim
+
+WORKDIR /app
+USER node
+COPY --from=tini --chown=node:node /tini /app/tini
+COPY --from=builder --chown=node:node /app/dist /app/dist
+COPY --from=productionDependencies --chown=node:node /app/node_modules /app/node_modules
+
+# Specified as entrypoint as you want the commands from waitehr to be added to the end of the script
+ENTRYPOINT ["/app/tini", "--", "node", "/app/dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ It is going to be a pretty hefty script, and if everyone (with their varying exp
 npm install waitehr --global
 ```
 
+## Run with Docker
+
+```bash
+docker build . -t waitehr:latest
+docker run waitehr:latest --help
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
This add a Dockerfile to provide this as a docker image. 

This will probably need some extra from your end if you want to publish this to Dockerhub as then an addition could be made to the README.md.

Final Docker Image size:

179MB - 175MB of that is [node:16-slim](https://hub.docker.com/layers/node/library/node/16-slim/images/sha256-df27e7dd385d35b7cc48d77d37bfd2e784bb4e2bc56da8ee8818a2a862d555ec?context=explore)

Reasons for specific things in the Dockerfile:

1. **Why npm install --production instead of npm ci in 'productionDependencies' stage.**

A comparison with the size of node_modules from npm ci vs npm install --production:

| Command | Size of node_modules |
| ---- | --- |
| npm ci | 250M |
| npm install --production | 4.7M |

Can check with `docker run -it --entrypoint=/bin/bash waitehr:ci` if you build with making the changes to the Dockerfile to use the different commands

2. **Why `tini` and what for?**

This is for proper handling of signals. Without tini the yargs command doesnt terminate correctly. I think it would be possible to have proper handling of signals but might be a more significant code change.

With `tini` the listening for SIGINT works as expected.