### PR TITLE
Add Headers option to allow request headers to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ while curl https://gajus.com/ | grep -q Gajus; do sleep 1; done
 
 However, by the time you add:
 
-* routine timeout
-* request timeout
-* follow redirects
-* max redirects
-* success threshold
+- routine timeout
+- request timeout
+- follow redirects
+- max redirects
+- success threshold
 
 It is going to be a pretty hefty script, and if everyone (with their varying experience of using Bash) were to write that script adhoc, it is likely to be error prone. It is for this reason that it makes sense to use a well tested utility that does it well.
 
@@ -55,6 +55,9 @@ waitehr https://gajus.com/ --status-code 200 404
 # Waits for response that contains "foo" and "bar".
 waitehr https://gajus.com/ --contains "foo" "bar"
 
+# Sends headers with the request if required to receive a valid response
+waitehr https://gajus.com/ --headers "Accepts: text/html" "Authorization: Bearer fkd9afsda9k"
+
 Options:
   --help               Show help                                       [boolean]
   --version            Show version number                             [boolean]
@@ -79,9 +82,12 @@ Options:
   --success-threshold  Minimum consecutive successes for the probe to be
                        considered successful.              [number] [default: 1]
   --timeout            How many seconds to wait before giving up.  [default: 60]
+  --headers            String request headers in the format
+                       <Header Key>: <Header Value>.
+                                                                   [array]
 ```
 
 ## Alternatives
 
-* [check_http](https://www.monitoring-plugins.org/doc/man/check_http.html) – Nagios plugin with equivalent functionality.
-* [httping](https://www.vanheusden.com/httping/) – utility for measuring latency and throughput of a webserver with limited some assertion capabilities.
+- [check_http](https://www.monitoring-plugins.org/doc/man/check_http.html) – Nagios plugin with equivalent functionality.
+- [httping](https://www.vanheusden.com/httping/) – utility for measuring latency and throughput of a webserver with limited some assertion capabilities.

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,10 @@ const argv = yargs(hideBin(process.argv))
       description: 'Defines if redirect responses should be followed automatically.',
       type: 'boolean',
     },
+    headers: {
+      description: 'String request headers in the format <Header Key>: <Header Value>.',
+      type: 'array',
+    },
     'initial-delay': {
       coerce: (value) => {
         return value * 1_000;

--- a/test/waitehr/waitResponse.ts
+++ b/test/waitehr/waitResponse.ts
@@ -213,3 +213,23 @@ test('waits at most requestTimeout', async (t) => {
 
   t.is(responseHandler.callCount, 5);
 });
+
+test('includes headers in request', async (t) => {
+  const app = fastify();
+
+  const responseHandler = sinon.spy((request, reply) => {
+    t.is(request.headers['x-foo'], 'bar');
+
+    void reply.send('OK');
+  });
+
+  app.get('/', responseHandler);
+
+  const address = await app.listen(0);
+
+  t.true(await waitResponse(address, {
+    headers: [
+      'x-foo: bar',
+    ],
+  }));
+});


### PR DESCRIPTION
Adds support for providing request headers as part of the `got` request.

Use-case - testing a URL that expects certain headers to be present before returning the expected response. Allows more specific testing.